### PR TITLE
에러 처리

### DIFF
--- a/FineDust.xcodeproj/project.pbxproj
+++ b/FineDust.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		69C1002E564CE2FB91179C033D174EEB /* RatioGraphViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB74F32A71DEF09C1E0BA1E3C00BBE2 /* RatioGraphViewDelegate.swift */; };
 		A51E6DAD7010A2182F400DB983564D54 /* RecentDustInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEBB8C71A7FB362DC9A9A7D132534A56 /* RecentDustInfo.swift */; };
 		5EE4CA05CA601AABFDC6F3D1989D135F /* RecommendCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BE6C39A1E9F23DBD0C1AF1B0E3DD9B /* RecommendCollectionViewCell.swift */; };
+		D43BB431919BE5B182944EBAA03278BA /* ResponseHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7247CE1DC76053F18FE04A31CE4860 /* ResponseHeader.swift */; };
+		585EA738C1263AEEE97962712EA4788B /* ServiceErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFACB8B8A628164CA222887EEA285687 /* ServiceErrorType.swift */; };
 		C921D4C99DA13AEB953E512F475F15C2 /* SharedInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72325220894EE5896332E4971553A6F7 /* SharedInfo.swift */; };
 		B500997103DB43D02E812611C3454782 /* Statistics.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DC70CCB69DBB1D392CC698DA0DC29071 /* Statistics.storyboard */; };
 		28C9DFA76618224E645C133EFD9B1794 /* StatisticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AB4A60A90E8A065BBA6004FB187F89 /* StatisticsViewController.swift */; };
@@ -228,6 +230,8 @@
 		ABB74F32A71DEF09C1E0BA1E3C00BBE2 /* RatioGraphViewDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RatioGraphViewDelegate.swift; sourceTree = "<group>"; };
 		FEBB8C71A7FB362DC9A9A7D132534A56 /* RecentDustInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentDustInfo.swift; sourceTree = "<group>"; };
 		48BE6C39A1E9F23DBD0C1AF1B0E3DD9B /* RecommendCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RecommendCollectionViewCell.swift; path = FineDust/Feedback/View/RecommendCollectionViewCell.swift; sourceTree = SOURCE_ROOT; };
+		EC7247CE1DC76053F18FE04A31CE4860 /* ResponseHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseHeader.swift; sourceTree = "<group>"; };
+		DFACB8B8A628164CA222887EEA285687 /* ServiceErrorType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceErrorType.swift; sourceTree = "<group>"; };
 		72325220894EE5896332E4971553A6F7 /* SharedInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedInfo.swift; sourceTree = "<group>"; };
 		DC70CCB69DBB1D392CC698DA0DC29071 /* Statistics.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Statistics.storyboard; sourceTree = "<group>"; };
 		58AB4A60A90E8A065BBA6004FB187F89 /* StatisticsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatisticsViewController.swift; sourceTree = "<group>"; };
@@ -324,6 +328,7 @@
 				768ED33DE8C563664122534CC0337E8E /* Hour.swift */,
 				648F2847BF0C37F32A03D356A9C8A1AE /* LocationObserver.swift */,
 				F489B34F713CED4C59D8449DF165CA2C /* ProgressIndicator.swift */,
+				DFACB8B8A628164CA222887EEA285687 /* ServiceErrorType.swift */,
 				BD765F536A1105FE2055510D17AF4578 /* Typealias.swift */,
 			);
 			path = Common;
@@ -517,6 +522,7 @@
 				D8EC047C4F060467C8A0D71A5763D757 /* DustGrade.swift */,
 				83C98043155CF43D3E5E4605CB1A88BE /* DustResponse.swift */,
 				AF4AD95023734A3CADFEB5F089113191 /* ObservatoryResponse.swift */,
+				EC7247CE1DC76053F18FE04A31CE4860 /* ResponseHeader.swift */,
 				771ADF487575031701FD3CE29CBA228C /* XMLParsingType.swift */,
 			);
 			path = Response;
@@ -899,6 +905,8 @@
 				69C1002E564CE2FB91179C033D174EEB /* RatioGraphViewDelegate.swift in Sources */,
 				A51E6DAD7010A2182F400DB983564D54 /* RecentDustInfo.swift in Sources */,
 				5EE4CA05CA601AABFDC6F3D1989D135F /* RecommendCollectionViewCell.swift in Sources */,
+				D43BB431919BE5B182944EBAA03278BA /* ResponseHeader.swift in Sources */,
+				585EA738C1263AEEE97962712EA4788B /* ServiceErrorType.swift in Sources */,
 				C921D4C99DA13AEB953E512F475F15C2 /* SharedInfo.swift in Sources */,
 				28C9DFA76618224E645C133EFD9B1794 /* StatisticsViewController.swift in Sources */,
 				BFA9B24EA42B5531A4E033E71F4F8EDD /* String+.swift in Sources */,

--- a/FineDust/Common/LocationObserver.swift
+++ b/FineDust/Common/LocationObserver.swift
@@ -35,6 +35,24 @@ protocol LocationObserver: class {
 
 extension LocationObserver where Self: UIViewController {
   
+  func handleIfFail(_ notification: Notification) {
+    if let error = notification.locationTaskError {
+      UIAlertController
+        .alert(title: "", message: error.localizedDescription)
+        .action(title: "확인")
+        .present(to: self)
+    }
+  }
+  
+  func handleIfAuthorizationDenied(_ notification: Notification) {
+    if let error = notification.locationTaskError {
+      UIAlertController
+        .alert(title: "", message: error.localizedDescription)
+        .action(title: "확인")
+        .present(to: self)
+    }
+  }
+  
   /// 위의 세 경우에 대한 옵저버 등록.
   func registerLocationObserver() {
     NotificationCenter.default.addObserver(

--- a/FineDust/Common/ServiceErrorType.swift
+++ b/FineDust/Common/ServiceErrorType.swift
@@ -1,0 +1,39 @@
+//
+//  ServiceErrorType.swift
+//  FineDust
+//
+//  Created by Presto on 11/02/2019.
+//  Copyright © 2019 boostcamp3rd. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// 서비스 메소드에서 나올 수 있는 사용자 정의 에러 타입.
+protocol ServiceErrorType: Error {
+  
+  /// 에러를 얼러트에 표시하기 위한 프로퍼티.
+  var alert: UIAlertController { get }
+}
+
+// MARK: - ServiceErrorType 프로토콜 초기 구현
+
+extension ServiceErrorType {
+  
+  var localizedDescription: String {
+    switch self {
+    case let error as HTTPError:
+      return error.localizedDescription
+    case let error as XMLError:
+      return error.localizedDescription
+    case let error as DustError:
+      return error.localizedDescription
+    default:
+      return "에러"
+    }
+  }
+  
+  var alert: UIAlertController {
+    return UIAlertController.alert(title: "", message: localizedDescription).action(title: "확인")
+  }
+}

--- a/FineDust/Common/Typealias.swift
+++ b/FineDust/Common/Typealias.swift
@@ -11,4 +11,5 @@ import Foundation
 /// 시간대별 흡입량 타입 별칭.
 typealias HourIntakePair = [Hour: Int]
 
+/// 날짜별 | 시간대별 흡입량 타입 별칭.
 typealias DateHourIntakePair = [Date: HourIntakePair]

--- a/FineDust/Dust/DustError.swift
+++ b/FineDust/Dust/DustError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// 미세먼지 API 오류 정의.
-enum DustError: Error {
+enum DustError: ServiceErrorType {
   
   /// 제공기관 서비스 상태가 원활하지 않음.
   case applicationError
@@ -56,7 +56,7 @@ enum DustError: Error {
 
 // MARK: - 에러 디스크립션
 
-extension DustError: LocalizedError {
+extension DustError {
   var localizedDescription: String {
     switch self {
     case .applicationError, .dbError, .httpError, .serviceTimeOut:

--- a/FineDust/Dust/DustInfoManagerType.swift
+++ b/FineDust/Dust/DustInfoManagerType.swift
@@ -49,6 +49,12 @@ extension DustInfoManagerType {
                   return
                 }
                 // XML 파싱하여 타입에 맞는 데이터로 캐스팅하여 넘겨줌.
+                XMLManager<ResponseHeader>().parse(data) { parsingType, error in
+                  if let error = error {
+                    completion(nil, error)
+                    return
+                  }
+                }
                 XMLManager<DustResponse>().parse(data) { parsingType, error in
                   let response = parsingType as? DustResponse
                   completion(response, error)

--- a/FineDust/Dust/DustObservatoryManagerType.swift
+++ b/FineDust/Dust/DustObservatoryManagerType.swift
@@ -45,6 +45,12 @@ extension DustObservatoryManagerType {
                   return
                 }
                 // XML 파싱하여 타입에 맞는 데이터로 캐스팅하여 넘겨줌.
+                XMLManager<ResponseHeader>().parse(data) { parsingType, error in
+                  if let error = error {
+                    completion(nil, error)
+                    return
+                  }
+                }
                 XMLManager<ObservatoryResponse>().parse(data) { parsingType, error in
                   let response = parsingType as? ObservatoryResponse
                   completion(response, error)

--- a/FineDust/Dust/XMLError.swift
+++ b/FineDust/Dust/XMLError.swift
@@ -11,7 +11,7 @@ import Foundation
 import SWXMLHash
 
 /// XML 파싱 에러 정의.
-enum XMLError: Error {
+enum XMLError: ServiceErrorType {
   
   case implementationIsMissing(String)
   

--- a/FineDust/Extension/UIAlertController+.swift
+++ b/FineDust/Extension/UIAlertController+.swift
@@ -44,7 +44,9 @@ extension UIAlertController {
                animated: Bool = true,
                completion: (() -> Void)? = nil) {
     DispatchQueue.main.async {
-      viewController?.present(self, animated: animated, completion: completion)
+      if !(viewController?.presentedViewController is UIAlertController) {
+        viewController?.present(self, animated: animated, completion: completion)
+      }
     }
   }
 }

--- a/FineDust/Extension/UIViewController+.swift
+++ b/FineDust/Extension/UIViewController+.swift
@@ -32,8 +32,10 @@ extension UIViewController {
                animated: Bool = true,
                completion: (() -> Void)? = nil) {
     modalTransitionStyle = style
-    DispatchQueue.main.async {
-      viewController.present(self, animated: animated, completion: completion)
+    if !(viewController.presentedViewController is UIAlertController) {
+      DispatchQueue.main.async {
+        viewController.present(self, animated: animated, completion: completion)
+      }
     }
   }
   

--- a/FineDust/Location/LocationManagerType.swift
+++ b/FineDust/Location/LocationManagerType.swift
@@ -73,7 +73,7 @@ extension LocationManagerType {
           NotificationCenter.default
             .post(name: .didFailUpdatingAllLocationTasks,
                   object: nil,
-                  userInfo: ["error": LocationTaskError.geoencodingError(error)])
+                  userInfo: ["error": LocationTaskError.geocodingError(error)])
           return
         }
         SharedInfo.shared.set(address: address ?? "")

--- a/FineDust/Location/LocationManagerType.swift
+++ b/FineDust/Location/LocationManagerType.swift
@@ -69,7 +69,7 @@ extension LocationManagerType {
                                              y: coordinate.latitude))
       SharedInfo.shared.set(x: convertedCoordinate?.x ?? 0, y: convertedCoordinate?.y ?? 0)
       GeocoderManager.shared.requestAddress(location) { address, error in
-        if let error = error {
+        if let error = error as? CLError {
           NotificationCenter.default
             .post(name: .didFailUpdatingAllLocationTasks,
                   object: nil,
@@ -80,9 +80,9 @@ extension LocationManagerType {
         let dustObservatoryManager = DustObservatoryManager()
         dustObservatoryManager.requestObservatory(numberOfRows: 1,
                                                 pageNumber: 1) { response, error in
-          if let error = error {
+          if let error = error as? DustError {
             NotificationCenter.default
-              .post(name: .didSuccessUpdatingAllLocationTasks,
+              .post(name: .didFailUpdatingAllLocationTasks,
                     object: nil,
                     userInfo: ["error": LocationTaskError.networkingError(error)])
             return
@@ -98,10 +98,12 @@ extension LocationManagerType {
   var errorHandler: ((Error) -> Void)? {
     return { error in
       // Core Location 작업 중 에러가 발생하면 관련 에러를 포함하여 노티피케이션을 쏴준다
-      NotificationCenter.default
-        .post(name: .didFailUpdatingAllLocationTasks,
-              object: nil,
-              userInfo: ["error": LocationTaskError.coreLocationError(error)])
+      if let error = error as? CLError {
+        NotificationCenter.default
+          .post(name: .didFailUpdatingAllLocationTasks,
+                object: nil,
+                userInfo: ["error": LocationTaskError.coreLocationError(error)])
+      }
     }
   }
 }

--- a/FineDust/Main/Controller/MainViewController.swift
+++ b/FineDust/Main/Controller/MainViewController.swift
@@ -54,8 +54,11 @@ extension MainViewController: LocationObserver {
       formatter.dateFormat = "a hh : mm"
       return formatter
     }()
-    
-    DustInfoService().requestRecentTimeInfo() { info, _ in
+    DustInfoService().requestRecentTimeInfo() { info, error in
+      if let error = error as? ServiceErrorType {
+        error.alert.present(to: self)
+        return 
+      }
       if let info = info {
         DispatchQueue.main.async {
           self.fineDustLabel.text = "\(info.fineDustValue)µg"
@@ -65,14 +68,6 @@ extension MainViewController: LocationObserver {
         }
       }
     }
-  }
-  
-  func handleIfFail(_ notification: Notification) {
-    
-  }
-  
-  func handleIfAuthorizationDenied(_ notification: Notification) {
-    
   }
 }
 

--- a/FineDust/Network/HTTPError.swift
+++ b/FineDust/Network/HTTPError.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// HTTP 통신 에러.
-enum HTTPError: Error {
+enum HTTPError: ServiceErrorType {
   
   case `default`
 }

--- a/FineDust/Response/ResponseHeader.swift
+++ b/FineDust/Response/ResponseHeader.swift
@@ -1,0 +1,28 @@
+//
+//  ResponseHeader.swift
+//  FineDust
+//
+//  Created by Presto on 11/02/2019.
+//  Copyright © 2019 boostcamp3rd. All rights reserved.
+//
+
+import Foundation
+
+import SWXMLHash
+
+/// 미세먼지 API의 Response 관련 부분을 먼저 파싱하기 위한 응답 객체.
+struct ResponseHeader: XMLParsingType {
+  
+  let code: Int
+  
+  let message: String
+  
+  static func deserialize(_ node: XMLIndexer) throws -> ResponseHeader {
+    return try ResponseHeader(code: node["response"]["header"]["resultCode"].value(),
+                              message: node["response"]["header"]["resultMsg"].value())
+  }
+  
+  var statusCode: DustStatusCode {
+    return DustStatusCode(rawValue: code) ?? .default
+  }
+}

--- a/FineDust/Statistics/StatisticsViewController.swift
+++ b/FineDust/Statistics/StatisticsViewController.swift
@@ -113,14 +113,14 @@ final class StatisticsViewController: UIViewController {
   /// 미세먼지 흡입량 요청.
   private func requestIntake() {
     requestWeekDustInfo { [weak self] fineDusts, ultrafineDusts, error in
-      if let error = error {
-        print(error.localizedDescription)
+      if let error = error as? ServiceErrorType {
+        error.alert.present(to: self)
         return
       }
       guard let self = self else { return }
       self.requestTodayDustInfo { [weak self] fineDust, ultrafineDust, error in
-        if let error = error {
-          print(error.localizedDescription)
+        if let error = error as? ServiceErrorType {
+          error.alert.present(to: self)
           return
         }
         guard let self = self else { return }
@@ -170,17 +170,6 @@ final class StatisticsViewController: UIViewController {
 extension StatisticsViewController: LocationObserver {
   func handleIfSuccess(_ notification: Notification) {
     requestIntake()
-  }
-  
-  func handleIfFail(_ notification: Notification) {
-    UIAlertController
-      .alert(title: "", message: notification.locationTaskError?.localizedDescription)
-      .action(title: "확인")
-      .present(to: self)
-  }
-  
-  func handleIfAuthorizationDenied(_ notification: Notification) {
-    print("authorization denied")
   }
 }
 

--- a/FineDust/Supporting Files/LocationTaskError.swift
+++ b/FineDust/Supporting Files/LocationTaskError.swift
@@ -6,17 +6,29 @@
 //  Copyright © 2019 boostcamp3rd. All rights reserved.
 //
 
+import CoreLocation
 import Foundation
 
 /// 앱델리게이트에서의 작업 중 에러 정의.
 enum LocationTaskError: Error {
   
   /// 주소 변환 작업 중 에러.
-  case geoencodingError(Error)
+  case geoencodingError(CLError)
   
   /// 관측소 정보 받아오는 중 에러.
-  case networkingError(Error)
+  case networkingError(DustError)
   
   /// 코어 로케이션 작업 중 에러.
-  case coreLocationError(Error)
+  case coreLocationError(CLError)
+  
+  var localizedDescription: String {
+    switch self {
+    case let .geoencodingError(error):
+      return error.localizedDescription
+    case let .networkingError(error):
+      return error.localizedDescription
+    case let .coreLocationError(error):
+      return error.localizedDescription
+    }
+  }
 }

--- a/FineDust/Supporting Files/LocationTaskError.swift
+++ b/FineDust/Supporting Files/LocationTaskError.swift
@@ -13,7 +13,7 @@ import Foundation
 enum LocationTaskError: Error {
   
   /// 주소 변환 작업 중 에러.
-  case geoencodingError(CLError)
+  case geocodingError(CLError)
   
   /// 관측소 정보 받아오는 중 에러.
   case networkingError(DustError)
@@ -23,7 +23,7 @@ enum LocationTaskError: Error {
   
   var localizedDescription: String {
     switch self {
-    case let .geoencodingError(error):
+    case let .geocodingError(error):
       return error.localizedDescription
     case let .networkingError(error):
       return error.localizedDescription


### PR DESCRIPTION
- `ServiceErrorType`은 서비스 메소드에서 나올 수 있는 에러 프로토콜이며, `XMLError`, `HTTPError`, `DustError`가 그렇습니다.

- `ResponseHeader` 응답 객체를 정의하여 먼저 미세먼지 API의 상태를 확인하고 이후 작업을 할 수 있도록 하였습니다. 